### PR TITLE
The target platforms have been migrated...

### DIFF
--- a/MSB.UI (Universal Windows)/MSB.UI (Universal Windows).csproj
+++ b/MSB.UI (Universal Windows)/MSB.UI (Universal Windows).csproj
@@ -1,8 +1,8 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
 	<PropertyGroup>
-		<TargetFramework>uap10.0.17763</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<TargetFramework>uap10.0.18362</TargetFramework>
+		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<NoWarn>CS8767;NETSDK1023</NoWarn>
 		<RootNamespace>MSB</RootNamespace>
 		<LangVersion>latest</LangVersion>

--- a/MSB.UI (Windows Presentation)/MSB.UI (Windows Presentation).csproj
+++ b/MSB.UI (Windows Presentation)/MSB.UI (Windows Presentation).csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0-windows</TargetFramework>
 		<NoWarn>CS8767;NETSDK1023</NoWarn>
 		<UseWPF>True</UseWPF>
 		<RootNamespace>MSB</RootNamespace>


### PR DESCRIPTION
The target platforms have been migrated from .NETCore 3.1 to .NET 6 and Windows 10 SDK 10.017763 to Windows 10 SDK 10.018362 respectively.